### PR TITLE
Tweaked naming schema for league threads, Issue 17

### DIFF
--- a/discord/funcs_discord.py
+++ b/discord/funcs_discord.py
@@ -93,8 +93,6 @@ async def announce_pairing(bot, guild):
     for row in rows:
         title = fgg.gen_pairing_thread_name(
             row.game_id,
-            season_name,
-            week_num,
             row.white_discord_name,
             row.black_discord_name,
         )

--- a/discord/funcs_general.py
+++ b/discord/funcs_general.py
@@ -30,9 +30,9 @@ def gen_substitute_thread_name(seed_id):
     name = f's{seed_id} Substitute Request'
     return name
 
-def gen_pairing_thread_name(game_id, season_name, week_num, white_name, black_name):
+def gen_pairing_thread_name(game_id, white_name, black_name):
     thread_name = (
-        f'g{game_id} {season_name} Week{week_num} | {white_name} vs {black_name}'
+        f'{white_name} vs {black_name} g{game_id}'
     )
     return thread_name
 


### PR DESCRIPTION
#17 

Updated the format to be `{White player} vs {Black player} g{game id}`. Also, removed unneeded parameters being passed as a result (season_num and week_num).